### PR TITLE
Add expo mobile screen

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,0 +1,11 @@
+{
+  "expo": {
+    "name": "ScrumMobile",
+    "slug": "scrum-mobile",
+    "version": "1.0.0",
+    "sdkVersion": "49.0.0",
+    "platforms": ["ios", "android", "web"],
+    "jsEngine": "hermes",
+    "entryPoint": "src/App.tsx"
+  }
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@panda-project/mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/App.tsx",
+  "scripts": {
+    "dev": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "expo-status-bar": "^1.4.4"
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react'
+import { SafeAreaView, View, Text, TextInput, Button, StyleSheet } from 'react-native'
+import { StatusBar } from 'expo-status-bar'
+
+export default function App() {
+  const [productName, setProductName] = useState('')
+  const [projectName, setProjectName] = useState('')
+
+  const handleSubmit = () => {
+    console.log('submit', productName, projectName)
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.form}>
+        <Text style={styles.title}>Scrum Management</Text>
+        <Text style={styles.desc}>本ソフトウェアはスクラムチームのタスク管理ツール（デモ用）です</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="プロダクト名"
+          value={productName}
+          onChangeText={setProductName}
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="プロジェクト名"
+          value={projectName}
+          onChangeText={setProjectName}
+        />
+        <Button title="保存する" onPress={handleSubmit} />
+      </View>
+      <StatusBar style="auto" />
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 24 },
+  form: {},
+  title: { fontSize: 18, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' },
+  desc: { fontSize: 12, color: '#666', marginBottom: 16, textAlign: 'center' },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4
+  }
+})

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@panda-project/config/base.json",
+  "compilerOptions": {
+    "jsx": "react",
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["src/*"]
+    }
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- set up expo project under `packages/apps/mobile`
- add initial screen replicating web initial form
- move mobile app to `apps/mobile`

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6841bff275fc8324813a87f7c5361bb8